### PR TITLE
Potential fix for code scanning alert no. 127: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -9,6 +9,9 @@ jobs:
   tidy:
     name: Tidy up
     runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - run: brew install tidy-html5


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/manifest/security/code-scanning/127](https://github.com/deadjdona/manifest/security/code-scanning/127)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- The `create-pull-request` action requires `contents: write` and `pull-requests: write`.
- Other steps in the workflow (e.g., `checkout` and `tidy-html5`) do not require additional permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`tidy`) to limit permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
