### PR TITLE
Potential fix for code scanning alert no. 126: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,6 +6,9 @@ on:
       - gh-pages
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-publish:
     name: Validate and Publish


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/manifest/security/code-scanning/126](https://github.com/deadjdona/manifest/security/code-scanning/126)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, `contents: read` is likely sufficient, as it involves checking out the repository and publishing specifications. If additional permissions are required for specific steps, they can be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`validate-and-publish`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
